### PR TITLE
Work around GitHub bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-***[Github bug - showing random avatar - not my cover](https://github.com/gosiaborzecka/gosiaborzecka/)***
-
-![](cover.png)
+![](https://github.com/gosiaborzecka/gosiaborzecka/raw/HEAD/cover.png)
 
 I'm a software developer that focus on Artificial Intelligence. 
 


### PR DESCRIPTION
There is a bug with the way that GitHub renders dynamic links on the profile readme pages.

In this example you have an image called 'cover.png' at the root of your repo therefore `![](cover.png}` works just fine in your https://github.com/gosiaborzecka/gosiaborzecka repo.

However, when that image is rendered from a profile readme page, it tries to load the image from the root of github.com, i.e.`https://github.com/cover.png`.

Turns out that we have a routing so that `https://github.com/USERNAME.png` will redirect you to the avatar for that user, so in this case the image returned is the avatar for https://github.com/cover

I've pinged the folks back at GitHub to fix this. In the meantime, easier way to get what you want is to link to the fully qualified path of your image.  Note that I'm using 'HEAD" as the branch name.  That way if you ever decide to change the name of your default branch (from say `master` to `main` then this link will still work)
